### PR TITLE
Fix typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ check:
 deps:
 	dep ensure
 	( cd frontend ; npm install )
-	( cd cleint ; npm install )
+	( cd client ; npm install )
 
 # Execute tests
 .PHONY: test


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #26 

---

## :construction_worker: Changes

Typo fix

- cleint -> client

## :flashlight: Testing Instructions
```
make deps
```
Does it work now?