### PR TITLE
Add travis job to check on protoc codegen

### DIFF
--- a/.scripts/install-protoc.sh
+++ b/.scripts/install-protoc.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# This script installs protoc for given platform (defaults to linux-x86_64).
+# See: https://github.com/protocolbuffers/protobuf/releases
+
+VERSION=3.6.1
+PLATFORM=$1
+if [ -z "$1" ] ; then
+  PLATFORM=linux-x86_64
+fi
+
+PROTOC_ZIP=protoc-$VERSION-$PLATFORM.zip
+echo Downloading $PROTOC_ZIP...
+curl -OL https://github.com/google/protobuf/releases/download/v$VERSION/$PROTOC_ZIP
+
+echo Unzipping $PROTOC_ZIP to /usr/local...
+sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
+
+echo Cleaning up...
+rm -f $PROTOC_ZIP

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,24 @@ after_success:
 
 matrix:
   include:
+    # Check if compiled code is up to date
+    - name: "Protoc Check"
+      language: go
+      go:
+        - "1.11"
+      install:
+        - bash .scripts/install-protoc.sh
+        - go get -u github.com/golang/protobuf/protoc-gen-go
+      script:
+        # generate code and exit with status 1 if diff is detected
+        - make proto
+        - git --no-pager diff protobuf
+        - git diff-index --relative=protobuf --quiet HEAD --
+      after_success: skip
+
     # Go components
-    - language: go
+    - name: "Core and Gateway Tests"
+      language: go
       go:
         - "1.11"
       env:
@@ -27,7 +43,8 @@ matrix:
         - go test -race -coverprofile=coverage.txt ./...
 
     # Frontend
-    - language: node_js
+    - name: "Frontend Tests"
+      language: node_js
       node_js:
         - "8.12"
       env:
@@ -42,7 +59,8 @@ matrix:
         - npm test -- --coverage 
 
     # Client
-    - language: node_js
+    - name: "Client Tests"
+      language: node_js
       node_js:
         - "8.12"
       env:


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #18

Depends on #41 

---

## :construction_worker: Changes

Travis now tries to compile the protobuf definitions and reports an error if anything goes wrong or the generated code is different from the committed code. This means we dont have to worry about forgetting to run `make proto`, travis will give us an alert

Added a script to install protoc

Added names for the different build jobs

## :flashlight: Testing Instructions

Check out the build: https://travis-ci.com/ubclaunchpad/pinpoint/builds/87829108