### PR TITLE
Gateway TLS and graceful shutdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,13 @@ gateway:
 	go run gateway/main.go run --dev \
 		--core.cert dev/certs/127.0.0.1.crt
 
+.PHONY: gateway-tls
+gateway-tls:
+	go run gateway/main.go run --dev \
+		--core.cert dev/certs/127.0.0.1.crt \
+		--tls.cert dev/certs/127.0.0.1.crt \
+		--tls.key dev/certs/127.0.0.1.key
+
 # Builds binary for pinpoint-core
 .PHONY: pinpoint-core
 pinpoint-core:

--- a/gateway/api/api.go
+++ b/gateway/api/api.go
@@ -155,7 +155,10 @@ func (a *API) Stop() {
 	a.srvLock.Lock()
 	if a.srv != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-		a.srv.Shutdown(ctx)
+		if err := a.srv.Shutdown(ctx); err != nil {
+			a.l.Warnw("error encountered during shutdown",
+				"error", err.Error())
+		}
 		cancel()
 	}
 	a.srvLock.Unlock()

--- a/gateway/api/api.go
+++ b/gateway/api/api.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
@@ -18,9 +19,10 @@ import (
 // API defines the API server. It is primarily a REST interface through which
 // service.Service can be accessed.
 type API struct {
-	l *zap.SugaredLogger
-	r *chi.Mux
-	c pinpoint.CoreClient
+	l   *zap.SugaredLogger
+	r   *chi.Mux
+	c   pinpoint.CoreClient
+	srv *http.Server
 }
 
 // New creates a new API server - start it using Run(). Returns a callback to
@@ -101,33 +103,53 @@ func (a *API) Run(host, port string, opts RunOpts) error {
 	defer conn.Close()
 
 	// attempt connection
-	_, err = a.c.GetStatus(context.Background(), &request.Status{})
-	if err != nil {
-		return fmt.Errorf("failed to connect to core service: %s", err.Error())
+	go func() {
+		if _, err = a.c.GetStatus(context.Background(), &request.Status{}); err != nil {
+			a.l.Errorw("unable to connect to core service",
+				"error", err.Error())
+		} else {
+			a.l.Info("established connection to core")
+		}
+	}()
+
+	// set up server
+	a.srv = &http.Server{
+		Addr:    host + ":" + port,
+		Handler: a.r,
 	}
 
 	// lets gooooo
+	tlsEnabled := opts.GatewayOpts.CertFile != ""
 	a.l.Infow("spinning up api server",
 		"gateway.host", host,
 		"gateway.port", port,
-		"gateway.tls", opts.GatewayOpts.CertFile != "")
-	addr := host + ":" + port
-	if opts.GatewayOpts.CertFile != "" {
-		err = http.ListenAndServeTLS(
-			addr,
-			opts.GatewayOpts.CertFile,
-			opts.GatewayOpts.KeyFile,
-			a.r)
+		"gateway.tls", tlsEnabled)
+	if tlsEnabled {
+		if err := a.srv.ListenAndServeTLS(
+			opts.GatewayOpts.CertFile, opts.GatewayOpts.KeyFile,
+		); err != nil && err != http.ErrServerClosed {
+			a.l.Warnw("error encountered - service stopped",
+				"error", err)
+			return err
+		}
 	} else {
-		err = http.ListenAndServe(addr, a.r)
-	}
-	if err != nil {
-		a.l.Errorf("error encountered - service stopped",
-			"error", err)
-		return err
+		if err := a.srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			a.l.Warnw("error encountered - service stopped",
+				"error", err)
+			return err
+		}
 	}
 
 	// report shutdown
 	a.l.Info("service shut down")
 	return nil
+}
+
+// Stop shuts down the API server
+func (a *API) Stop() {
+	if a.srv != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		a.srv.Shutdown(ctx)
+		cancel()
+	}
 }

--- a/gateway/api/api.go
+++ b/gateway/api/api.go
@@ -145,7 +145,7 @@ func (a *API) Run(host, port string, opts RunOpts) error {
 	return nil
 }
 
-// Stop shuts down the API server
+// Stop releases resources and shuts down the API server
 func (a *API) Stop() {
 	if a.srv != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/gateway/api/api_test.go
+++ b/gateway/api/api_test.go
@@ -21,35 +21,39 @@ func TestAPI_Run(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	api, err := New(l)
-	if err != nil {
-		t.Error(err)
-		return
+
+	type args struct {
+		opts RunOpts
 	}
-
-	// stub run
-	go api.Run("localhost", "8080", RunOpts{})
-	time.Sleep(time.Millisecond)
-	api.Stop()
-
-	// stub run with core tls
-	go api.Run("localhost", "8080", RunOpts{
-		CoreOpts: CoreOpts{
-			Host:     "localhost",
-			Port:     "9111",
-			CertFile: "../../dev/certs/127.0.0.1.crt",
-		},
-	})
-	time.Sleep(time.Millisecond)
-	api.Stop()
-
-	// stub run with gateway tls
-	go api.Run("localhost", "8081", RunOpts{
-		GatewayOpts: GatewayOpts{
-			CertFile: "../../dev/certs/127.0.0.1.crt",
-			KeyFile:  "../../dev/certs/127.0.0.1.key",
-		},
-	})
-	time.Sleep(time.Millisecond)
-	api.Stop()
+	tests := []struct {
+		name string
+		args args
+	}{
+		{"no options", args{RunOpts{}}},
+		{"with core TLS", args{RunOpts{
+			CoreOpts: CoreOpts{
+				Host:     "localhost",
+				Port:     "9111",
+				CertFile: "../../dev/certs/127.0.0.1.crt",
+			},
+		}}},
+		{"with gateway TLS", args{RunOpts{
+			GatewayOpts: GatewayOpts{
+				CertFile: "../../dev/certs/127.0.0.1.crt",
+				KeyFile:  "../../dev/certs/127.0.0.1.key",
+			},
+		}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api, err := New(l)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			go api.Run("localhost", "8080", tt.args.opts)
+			time.Sleep(time.Millisecond)
+			api.Stop()
+		})
+	}
 }

--- a/gateway/api/api_test.go
+++ b/gateway/api/api_test.go
@@ -30,4 +30,26 @@ func TestAPI_Run(t *testing.T) {
 	// stub run
 	go api.Run("localhost", "8080", RunOpts{})
 	time.Sleep(time.Millisecond)
+	api.Stop()
+
+	// stub run with core tls
+	go api.Run("localhost", "8080", RunOpts{
+		CoreOpts: CoreOpts{
+			Host:     "localhost",
+			Port:     "9111",
+			CertFile: "../../dev/certs/127.0.0.1.crt",
+		},
+	})
+	time.Sleep(time.Millisecond)
+	api.Stop()
+
+	// stub run with gateway tls
+	go api.Run("localhost", "8081", RunOpts{
+		GatewayOpts: GatewayOpts{
+			CertFile: "../../dev/certs/127.0.0.1.crt",
+			KeyFile:  "../../dev/certs/127.0.0.1.key",
+		},
+	})
+	time.Sleep(time.Millisecond)
+	api.Stop()
 }


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #50

Blocked by #52 

---

## :construction_worker: Changes

Most of the stuff to enable gateway TLS was done in #52 - this PR adds a few changes geared towards the gateway:
- a script to demo gateway TLS usage
- graceful gateway shutdown function via `API::Stop()`, similar to what I added for `core` in #52

## :flashlight: Testing Instructions

```sh
make gateway-tls
curl localhost:8081/status # should error
curl https://localhost:8081/status # should also error, because our cert is self-signed
curl https://localhost:8081/status --insecure # gucci!
```
