### PR TITLE
gateway: improve period validation

### DIFF
--- a/gateway/api/club.go
+++ b/gateway/api/club.go
@@ -71,19 +71,25 @@ func (club *ClubRouter) createClub(w http.ResponseWriter, r *http.Request) {
 }
 
 func (club *ClubRouter) createPeriod(w http.ResponseWriter, r *http.Request) {
-	var decoder = json.NewDecoder(r.Body)
-	var data schema.CreatePeriod
+	var (
+		decoder    = json.NewDecoder(r.Body)
+		data       schema.CreatePeriod
+		err        error
+		start, end time.Time
+	)
 	if err := decoder.Decode(&data); err != nil {
 		render.Render(w, r, res.ErrBadRequest(r, err, "Invalid input"))
 		return
 	}
 
 	// parse form date input into standard format
-	layout := "2006-01-02"
-	start, err := time.Parse(layout, data.Start)
-	end, err := time.Parse(layout, data.End)
-	if err != nil {
-		render.Render(w, r, res.ErrBadRequest(r, err, "Invalid input"))
+	const layout = "2006-01-02"
+	if start, err = time.Parse(layout, data.Start); err != nil {
+		render.Render(w, r, res.ErrBadRequest(r, err, "Invalid start date"))
+		return
+	}
+	if end, err = time.Parse(layout, data.End); err != nil {
+		render.Render(w, r, res.ErrBadRequest(r, err, "Invalid end date"))
 		return
 	}
 

--- a/gateway/api/club.go
+++ b/gateway/api/club.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -90,6 +91,12 @@ func (club *ClubRouter) createPeriod(w http.ResponseWriter, r *http.Request) {
 	}
 	if end, err = time.Parse(layout, data.End); err != nil {
 		render.Render(w, r, res.ErrBadRequest(r, err, "Invalid end date"))
+		return
+	}
+
+	// check validity
+	if start.After(end) {
+		render.Render(w, r, res.ErrBadRequest(r, errors.New("Start date must be before end date"), ""))
 		return
 	}
 

--- a/gateway/api/club_test.go
+++ b/gateway/api/club_test.go
@@ -88,16 +88,21 @@ func TestClubRouter_createPeriod(t *testing.T) {
 		wantCode int
 	}{
 		{"bad input", args{nil}, http.StatusBadRequest},
+		{"invalid start", args{&schema.CreatePeriod{
+			Name:  "Winter Semester",
+			Start: "2018asdasdfawkjefe-09",
+			End:   "2018-08-09",
+		}}, http.StatusBadRequest},
+		{"invalid end", args{&schema.CreatePeriod{
+			Name:  "Winter Semester",
+			Start: "2018-08-09",
+			End:   "2018-08asdfasdfasdf-12",
+		}}, http.StatusBadRequest},
 		{"successfully create period", args{&schema.CreatePeriod{
 			Name:  "Winter Semester",
 			Start: "2018-08-09",
-			End:   "2018-08-12",
+			End:   "2018-08-10",
 		}}, http.StatusCreated},
-		{"successfully create period", args{&schema.CreatePeriod{
-			Name:  "Winter Semester",
-			Start: "2018asdasdfawkjefe-09",
-			End:   "2018-08asdfasdfasdf-12",
-		}}, http.StatusBadRequest},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/gateway/api/club_test.go
+++ b/gateway/api/club_test.go
@@ -98,6 +98,11 @@ func TestClubRouter_createPeriod(t *testing.T) {
 			Start: "2018-08-09",
 			End:   "2018-08asdfasdfasdf-12",
 		}}, http.StatusBadRequest},
+		{"end before start", args{&schema.CreatePeriod{
+			Name:  "Winter Semester",
+			Start: "2018-08-15",
+			End:   "2018-08-10",
+		}}, http.StatusBadRequest},
 		{"successfully create period", args{&schema.CreatePeriod{
 			Name:  "Winter Semester",
 			Start: "2018-08-09",

--- a/gateway/api/club_test.go
+++ b/gateway/api/club_test.go
@@ -111,14 +111,12 @@ func TestClubRouter_createPeriod(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fake := &fakes.FakeCoreClient{}
-
 			// create club router
+			fake := &fakes.FakeCoreClient{}
 			u := newClubRouter(l, fake)
 
 			// create request
 			var b []byte
-			// var err error
 			if tt.args.period != nil {
 				if b, err = json.Marshal(tt.args.period); err != nil {
 					t.Error(err)


### PR DESCRIPTION
:tickets: **Ticket(s)**: For #46

---

## :construction_worker: Changes

Adds some validation that was missed by @suujia and I in #92

## :flashlight: Testing Instructions

```bash
go test github.com/ubclaunchpad/pinpoint/gateway/api -run ^TestClubRouter_createPeriod$
```
