### PR TITLE
Bump NodeJS version, lock terser to 3.14.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ matrix:
     - name: "Frontend Tests"
       language: node_js
       node_js:
-        - "8.12"
+        - "10.15"
       env:
         # CI=false is temporary to prevent console prints failing builds
         - TEST="frontend" CI=false
@@ -71,7 +71,7 @@ matrix:
     - name: "Client Tests"
       language: node_js
       node_js:
-        - "8.12"
+        - "10.15"
       env:
         - TEST="client"
       before_install: cd client

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "react-datepicker": "2.0.0",
     "react-dom": "16.7.0",
     "react-router-dom": "4.3.1",
-    "react-scripts": "2.1.3"
+    "react-scripts": "2.1.3",
+    "terser": "3.14.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
:tickets: **Ticket(s)**: n/a

---

## :construction_worker: Changes

* Bumps NodeJS to the new LTS version
* Fixes build issues that are affecting #124 and #125 by locking to `terser@3.14.1` (see terser-js/terser#251, vuejs/vue-cli#3407)

## :flashlight: Testing Instructions

See CI passing

Also try `cd frontend ; npm run build`
