### PR TITLE
gateway: fix package res, improve response structure standardization

### DIFF
--- a/gateway/api/club/club.go
+++ b/gateway/api/club/club.go
@@ -71,26 +71,26 @@ func (c *Router) createEvent(w http.ResponseWriter, r *http.Request) {
 	var decoder = json.NewDecoder(r.Body)
 	var data schema.CreateEvent
 	if err := decoder.Decode(&data); err != nil {
-		render.Render(w, r, res.ErrBadRequest(r, "invalid request"))
+		render.Render(w, r, res.ErrBadRequest("invalid request"))
 		return
 	}
 
 	// TODO: create event in core
 
-	render.Render(w, r, res.Message(r, "Event created successfully", http.StatusCreated))
+	render.Render(w, r, res.Msg("Event created successfully", http.StatusCreated))
 }
 
 func (c *Router) createClub(w http.ResponseWriter, r *http.Request) {
 	var decoder = json.NewDecoder(r.Body)
 	var data schema.CreateClub
 	if err := decoder.Decode(&data); err != nil {
-		render.Render(w, r, res.ErrBadRequest(r, "invalid request"))
+		render.Render(w, r, res.ErrBadRequest("invalid request"))
 		return
 	}
 
 	// TODO: create club in core
 
-	render.Render(w, r, res.Message(r, "Club created successfully", http.StatusCreated))
+	render.Render(w, r, res.Msg("Club created successfully", http.StatusCreated))
 }
 
 func (c *Router) createPeriod(w http.ResponseWriter, r *http.Request) {
@@ -101,29 +101,29 @@ func (c *Router) createPeriod(w http.ResponseWriter, r *http.Request) {
 		start, end time.Time
 	)
 	if err := decoder.Decode(&data); err != nil {
-		render.Render(w, r, res.ErrBadRequest(r, "invalid request"))
+		render.Render(w, r, res.ErrBadRequest("invalid request"))
 		return
 	}
 
 	// parse form date input into standard format
 	const layout = "2006-01-02"
 	if start, err = time.Parse(layout, data.Start); err != nil {
-		render.Render(w, r, res.ErrBadRequest(r, "invalid start date"))
+		render.Render(w, r, res.ErrBadRequest("invalid start date"))
 		return
 	}
 	if end, err = time.Parse(layout, data.End); err != nil {
-		render.Render(w, r, res.ErrBadRequest(r, "invalid end date"))
+		render.Render(w, r, res.ErrBadRequest("invalid end date"))
 		return
 	}
 
 	// check validity
 	if start.After(end) {
-		render.Render(w, r, res.ErrBadRequest(r, "start date must be before end date"))
+		render.Render(w, r, res.ErrBadRequest("start date must be before end date"))
 		return
 	}
 
 	// TODO: create period in core, for now just log
 	fmt.Println(start, end)
 
-	render.Render(w, r, res.Message(r, "period created sucessfully", http.StatusCreated))
+	render.Render(w, r, res.Msg("period created sucessfully", http.StatusCreated))
 }

--- a/gateway/api/handlers.go
+++ b/gateway/api/handlers.go
@@ -11,7 +11,7 @@ import (
 func (a *API) statusHandler(w http.ResponseWriter, r *http.Request) {
 	resp, err := a.c.GetStatus(r.Context(), &request.Status{})
 	if err != nil {
-		render.Render(w, r, res.ErrInternalServer(r, err.Error()))
+		render.Render(w, r, res.ErrInternalServer("failed to retrieve Core status", err))
 		return
 	}
 	render.JSON(w, r, resp)

--- a/gateway/api/user/user.go
+++ b/gateway/api/user/user.go
@@ -72,11 +72,9 @@ func (u *Router) login(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// No error means authenticated, proceed to generate token
-	w.WriteHeader(http.StatusOK)
 	// TODO: Generate token. See #10
-	render.JSON(w, r, map[string]string{
-		"token": "1234",
-	})
+	render.Render(w, r, res.MsgOK("user logged in",
+		"token", 1234))
 }
 
 func (u *Router) verify(w http.ResponseWriter, r *http.Request) {

--- a/gateway/api/user/user.go
+++ b/gateway/api/user/user.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-chi/chi"
 	"github.com/go-chi/render"
 	"github.com/ubclaunchpad/pinpoint/gateway/res"
-	"github.com/ubclaunchpad/pinpoint/protobuf"
+	pinpoint "github.com/ubclaunchpad/pinpoint/protobuf"
 	"github.com/ubclaunchpad/pinpoint/protobuf/request"
 	"go.uber.org/zap"
 )
@@ -40,20 +40,19 @@ func (u *Router) createUser(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var user request.CreateAccount
 	if err := decoder.Decode(&user); err != nil {
-		render.Render(w, r, res.ErrBadRequest(r, "invalid request"))
+		render.Render(w, r, res.ErrBadRequest("invalid request"))
 		return
 	}
 
 	// create account in core
 	resp, err := u.c.CreateAccount(r.Context(), &user)
 	if err != nil {
-		render.Render(w, r, res.ErrInternalServer(r, "failed to create user account",
-			"error", err.Error()))
+		render.Render(w, r, res.ErrInternalServer("failed to create user account", err))
 		return
 	}
 
 	// success!
-	render.Render(w, r, res.Message(r, resp.GetMessage(), http.StatusCreated,
+	render.Render(w, r, res.Msg(resp.GetMessage(), http.StatusCreated,
 		"email", user.GetEmail()))
 }
 
@@ -61,14 +60,14 @@ func (u *Router) login(w http.ResponseWriter, r *http.Request) {
 	email := r.FormValue("email")
 	password := r.FormValue("password")
 	if email == "" || password == "" {
-		render.Render(w, r, res.ErrBadRequest(r, "missing fields - both email and password is required"))
+		render.Render(w, r, res.ErrBadRequest("missing fields - both email and password is required"))
 		return
 	}
 
 	if _, err := u.c.Login(r.Context(), &request.Login{
 		Email: email, Password: password,
 	}); err != nil {
-		render.Render(w, r, res.ErrUnauthorized(r, err.Error()))
+		render.Render(w, r, res.ErrUnauthorized(err.Error()))
 		return
 	}
 
@@ -83,15 +82,15 @@ func (u *Router) login(w http.ResponseWriter, r *http.Request) {
 func (u *Router) verify(w http.ResponseWriter, r *http.Request) {
 	hash := r.FormValue("hash")
 	if hash == "" {
-		render.Render(w, r, res.ErrBadRequest(r, "hash is required"))
+		render.Render(w, r, res.ErrBadRequest("hash is required"))
 		return
 	}
 
 	resp, err := u.c.Verify(r.Context(), &request.Verify{Hash: hash})
 	if err != nil {
-		render.Render(w, r, res.Err(r, err.Error(), http.StatusNotFound))
+		render.Render(w, r, res.ErrNotFound(err.Error()))
 		return
 	}
 
-	render.Render(w, r, res.Message(r, resp.GetMessage(), http.StatusAccepted))
+	render.Render(w, r, res.Msg(resp.GetMessage(), http.StatusAccepted))
 }

--- a/gateway/res/base.go
+++ b/gateway/res/base.go
@@ -7,7 +7,8 @@ import (
 	"github.com/go-chi/render"
 )
 
-type baseResponse struct {
+// BaseResponse is the underlying structure of all API responses
+type BaseResponse struct {
 	// Basic metadata
 	HTTPStatusCode int    `json:"code"`
 	RequestID      string `json:"request_id,omitempty"`
@@ -26,7 +27,7 @@ func newBaseResponse(
 	message string,
 	code int,
 	kvs []interface{},
-) *baseResponse {
+) *BaseResponse {
 	var data = make(map[string]interface{})
 	var e string
 	for i := 0; i < len(kvs)-1; i += 2 {
@@ -45,7 +46,7 @@ func newBaseResponse(
 			data[k] = v
 		}
 	}
-	return &baseResponse{
+	return &BaseResponse{
 		HTTPStatusCode: code,
 		Message:        message,
 		Err:            e,
@@ -53,7 +54,8 @@ func newBaseResponse(
 	}
 }
 
-func (b *baseResponse) Render(w http.ResponseWriter, r *http.Request) error {
+// Render implements chi/render.Render
+func (b *BaseResponse) Render(w http.ResponseWriter, r *http.Request) error {
 	b.RequestID = reqID(r)
 	render.Status(r, b.HTTPStatusCode)
 	return nil

--- a/gateway/res/base.go
+++ b/gateway/res/base.go
@@ -1,18 +1,67 @@
 package res
 
-import "net/http"
+import (
+	"net/http"
 
-// BaseResponse is the underlying response structure to all responses
-type BaseResponse struct {
-	HTTPStatusCode int                    `json:"-"`
-	Message        string                 `json:"message"`
-	RequestID      string                 `json:"request-id"`
-	Body           map[string]interface{} `json:"body,omitempty"`
+	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/render"
+)
+
+type baseResponse struct {
+	// Basic metadata
+	HTTPStatusCode int    `json:"code"`
+	RequestID      string `json:"request_id,omitempty"`
+
+	// Message is included in all responses, and is a summary of the server's response
+	Message string `json:"message"`
+
+	// Err contains additional context in the event of an error
+	Err string `json:"error,omitempty"`
+
+	// Data contains information the server wants to return
+	Data interface{} `json:"data,omitempty"`
 }
 
-func newBaseRequest(r *http.Request, message string, code int, kvs []interface{}) BaseResponse {
-	return BaseResponse{
+func newBaseResponse(
+	message string,
+	code int,
+	kvs []interface{},
+) *baseResponse {
+	var data = make(map[string]interface{})
+	var e string
+	for i := 0; i < len(kvs)-1; i += 2 {
+		var (
+			k = kvs[i].(string)
+			v = kvs[i+1]
+		)
+		if k == "error" {
+			switch err := v.(type) {
+			case error:
+				e = err.Error()
+			case string:
+				e = err
+			}
+		} else {
+			data[k] = v
+		}
+	}
+	return &baseResponse{
 		HTTPStatusCode: code,
 		Message:        message,
+		Err:            e,
+		Data:           data,
 	}
+}
+
+func (b *baseResponse) Render(w http.ResponseWriter, r *http.Request) error {
+	b.RequestID = reqID(r)
+	render.Status(r, b.HTTPStatusCode)
+	return nil
+}
+
+func reqID(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	return middleware.GetReqID(r.Context())
 }

--- a/gateway/res/base.go
+++ b/gateway/res/base.go
@@ -67,6 +67,11 @@ func formatData(kvs []interface{}) (e string, d interface{}) {
 		}
 	}
 
+	// We need to make sure we *explicitly* return a nil-value interface, since
+	// if we assign a map, even if it is null, an empty interface will now assume
+	// a type value, making it non-nil, which means the `omitempty` directive will
+	// no longer trigger.
+	// See https://golang.org/doc/faq#nil_error
 	if len(data) < 1 {
 		return e, nil
 	}

--- a/gateway/res/error.go
+++ b/gateway/res/error.go
@@ -39,5 +39,5 @@ func ErrForbidden(message string, kvs ...interface{}) *ErrResponse {
 
 // ErrNotFound is a shortcut for forbidden requests
 func ErrNotFound(message string, kvs ...interface{}) *ErrResponse {
-	return &ErrResponse{newBaseResponse(message, http.StatusForbidden, kvs)}
+	return &ErrResponse{newBaseResponse(message, http.StatusNotFound, kvs)}
 }

--- a/gateway/res/error.go
+++ b/gateway/res/error.go
@@ -6,7 +6,7 @@ import (
 
 // ErrResponse is the template for a typical HTTP response for errors
 type ErrResponse struct {
-	*baseResponse
+	*BaseResponse
 }
 
 // Err is a basic error response constructor

--- a/gateway/res/error.go
+++ b/gateway/res/error.go
@@ -2,45 +2,42 @@ package res
 
 import (
 	"net/http"
-
-	"github.com/go-chi/render"
 )
 
 // ErrResponse is the template for a typical HTTP response for errors
 type ErrResponse struct {
-	BaseResponse
-}
-
-// Render renders an ErrResponse
-func (e *ErrResponse) Render(w http.ResponseWriter, r *http.Request) error {
-	render.Status(r, e.HTTPStatusCode)
-	return nil
+	*baseResponse
 }
 
 // Err is a basic error response constructor
-func Err(r *http.Request, message string, code int, kvs ...interface{}) render.Renderer {
-	return &ErrResponse{
-		BaseResponse: newBaseRequest(r, message, code, kvs),
-	}
+func Err(message string, code int, kvs ...interface{}) *ErrResponse {
+	return &ErrResponse{newBaseResponse(message, code, kvs)}
 }
 
-// ErrInternalServer is a shortcut for internal server errors
-func ErrInternalServer(r *http.Request, message string, kvs ...interface{}) render.Renderer {
-	return &ErrResponse{
-		BaseResponse: newBaseRequest(r, message, http.StatusInternalServerError, kvs),
-	}
+// ErrInternalServer is a shortcut for internal server errors. It should be
+// accompanied by an actual error.
+func ErrInternalServer(message string, err error, kvs ...interface{}) *ErrResponse {
+	var b = newBaseResponse(message, http.StatusInternalServerError, kvs)
+	b.Err = err.Error()
+	return &ErrResponse{b}
 }
 
 // ErrBadRequest is a shortcut for bad requests
-func ErrBadRequest(r *http.Request, message string, kvs ...interface{}) render.Renderer {
-	return &ErrResponse{
-		BaseResponse: newBaseRequest(r, message, http.StatusBadRequest, kvs),
-	}
+func ErrBadRequest(message string, kvs ...interface{}) *ErrResponse {
+	return &ErrResponse{newBaseResponse(message, http.StatusBadRequest, kvs)}
 }
 
 // ErrUnauthorized is a shortcut for unauthorized requests
-func ErrUnauthorized(r *http.Request, message string, kvs ...interface{}) render.Renderer {
-	return &ErrResponse{
-		BaseResponse: newBaseRequest(r, message, http.StatusUnauthorized, kvs),
-	}
+func ErrUnauthorized(message string, kvs ...interface{}) *ErrResponse {
+	return &ErrResponse{newBaseResponse(message, http.StatusUnauthorized, kvs)}
+}
+
+// ErrForbidden is a shortcut for forbidden requests
+func ErrForbidden(message string, kvs ...interface{}) *ErrResponse {
+	return &ErrResponse{newBaseResponse(message, http.StatusForbidden, kvs)}
+}
+
+// ErrNotFound is a shortcut for forbidden requests
+func ErrNotFound(message string, kvs ...interface{}) *ErrResponse {
+	return &ErrResponse{newBaseResponse(message, http.StatusForbidden, kvs)}
 }

--- a/gateway/res/message.go
+++ b/gateway/res/message.go
@@ -1,25 +1,18 @@
 package res
 
-import (
-	"net/http"
-
-	"github.com/go-chi/render"
-)
+import "net/http"
 
 // MsgResponse is the template for a typical HTTP response for messages
 type MsgResponse struct {
-	BaseResponse
+	*baseResponse
 }
 
-// Render renders a MsgResponse
-func (m *MsgResponse) Render(w http.ResponseWriter, r *http.Request) error {
-	render.Status(r, m.HTTPStatusCode)
-	return nil
+// Msg is a shortcut for non-error statuses
+func Msg(message string, code int, kvs ...interface{}) *MsgResponse {
+	return &MsgResponse{newBaseResponse(message, code, kvs)}
 }
 
-// Message is a shortcut for non-error statuses
-func Message(r *http.Request, message string, code int, kvs ...interface{}) render.Renderer {
-	return &MsgResponse{
-		BaseResponse: newBaseRequest(r, message, code, kvs),
-	}
+// MsgOK is a shortcut for an ok-status response
+func MsgOK(message string, kvs ...interface{}) *MsgResponse {
+	return &MsgResponse{newBaseResponse(message, http.StatusOK, kvs)}
 }

--- a/gateway/res/message.go
+++ b/gateway/res/message.go
@@ -4,7 +4,7 @@ import "net/http"
 
 // MsgResponse is the template for a typical HTTP response for messages
 type MsgResponse struct {
-	*baseResponse
+	*BaseResponse
 }
 
 // Msg is a shortcut for non-error statuses


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #131

---

## :construction_worker: Changes

* Remove redundant argument (http request) for response constructors (these are available on `Render()`
* Set request ID on responses
* Streamline structure of `BaseResponse`:

```go
type baseResponse struct {
	// Basic metadata
	HTTPStatusCode int    `json:"code"`
	RequestID      string `json:"request_id,omitempty"`

	// Message is included in all responses, and is a summary of the server's response
	Message string `json:"message"`

	// Err contains additional context in the event of an error
	Err string `json:"error,omitempty"`

	// Data contains information the server wants to return
	Data interface{} `json:"data,omitempty"`
}
```

## :flashlight: Testing Instructions

all tests should pass, changes should not introduce incompatibilities yet