### PR TITLE
 Help command for makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ VERSION=`git rev-parse --short HEAD`
 DEV_ENV=export `less ./dev/.env | xargs`
 TEST_COMPOSE=docker-compose -f dev/testenv.yml -p test
 MON_COMPOSE=docker-compose -f dev/monitoring.yml -p monitoring
+PROJECTNAME=$(shell basename "$(PWD)")
 
 ## all: Runs check
 all: check

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ VERSION=`git rev-parse --short HEAD`
 DEV_ENV=export `less ./dev/.env | xargs`
 TEST_COMPOSE=docker-compose -f dev/testenv.yml -p test
 MON_COMPOSE=docker-compose -f dev/monitoring.yml -p monitoring
-PROJECTNAME=$(shell basename "$(PWD)")
 
 ## all: Runs check
 all: check
@@ -142,6 +141,7 @@ pinpoint-gateway:
     -ldflags "-X main.Version=$(VERSION)" \
     ./gateway $(FLAGS)
 
+.PHONY: help
 help: Makefile
-	@echo " Choose a command run in "$(PROJECTNAME)":"
+	@echo " Choose a command run in pinpoint:"
 	@sed -n 's/^##//p' $< | column -t -s ':' |  sed -e 's/^/ /'

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ You will need [dep](https://github.com/golang/dep#installation) and [npm](https:
 $> make deps
 ```
 
+### Makefile
+
+The [Makefile](/Makefile) offers a lot of useful commands for development. Run
+`make help` to see the commands that are available.
+
 ### Building
 
 #### Golang Binaries


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes 🙆🏻‍♀️


I always forget all the commands and have to go to the file to look them up


---

## :construction_worker: Changes

command to reveal commands

## :flashlight: Testing Instructions

How convenient is this: 

```
$make help

Choose a command run in pinpoint:
  all                Runs check
  check              Run simple checks
  deps               Install dependencies
  test               Execute tests
  testenv            Set up test environment
  testenv-stop       Stop test environment
  monitoring         Set up monitoring environment
  monitoring-stop    Stop monitoring environment
  clean              Clean up stuff
  lint               Run linters and checks
  gen                Regenerate all generated code
  proto              Generate protobuf code from definitions
  proto-pkg          Runs protoc definitions 
  mocks              Generate database interface and mock
  core               Runs core service
  gateway            Runs API gateway
  gateway-tls        Runs gateway tls 
  web                Runs web app
  pinpoint-core      Builds binary for pinpoint-core
  pinpoint-gateway   Builds binary for pinpoint-gateway
```

